### PR TITLE
Add CI/CD workflows for jackfruit (INF-04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,5 +5,27 @@ on:
     branches: [main]
 
 jobs:
+  detect:
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      serving: ${{ steps.filter.outputs.serving }}
+      pipeline: ${{ steps.filter.outputs.pipeline }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            serving:
+              - 'serving-go/**'
+              - '.github/workflows/**'
+            pipeline:
+              - 'pipeline-python/**'
+              - '.github/workflows/**'
+
   test:
+    needs: detect
     uses: ./.github/workflows/test.yml
+    with:
+      run-serving: ${{ needs.detect.outputs.serving == 'true' }}
+      run-pipeline: ${{ needs.detect.outputs.pipeline == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       pipeline: ${{ steps.filter.outputs.pipeline }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,9 +61,6 @@ jobs:
           cache-from: type=gha,scope=pipeline-python
           cache-to: type=gha,scope=pipeline-python,mode=max
 
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v5
-
       - name: Configure kubeconfig
         env:
           KUBECONFIG_CONTENT: ${{ secrets.KUBECONFIG }}
@@ -74,22 +71,23 @@ jobs:
 
       - name: Deploy to Kapsule
         id: deploy
-        env:
-          SHA: ${{ steps.vars.outputs.sha_short }}
         run: |
           kubectl set image deployment/jackfruit-api \
-            jackfruit-api=${REGISTRY}/jackfruit-api:${SHA}
+            jackfruit-api=${{ env.REGISTRY }}/jackfruit-api:${{ steps.vars.outputs.sha_short }}
           kubectl set image deployment/dagster-daemon \
-            dagster-daemon=${REGISTRY}/pipeline-python:${SHA}
+            dagster-daemon=${{ env.REGISTRY }}/pipeline-python:${{ steps.vars.outputs.sha_short }}
           kubectl set image deployment/dagster-webserver \
-            dagster-webserver=${REGISTRY}/pipeline-python:${SHA}
+            dagster-webserver=${{ env.REGISTRY }}/pipeline-python:${{ steps.vars.outputs.sha_short }}
 
       - name: Wait for rollout
         run: |
           kubectl rollout status deployment/jackfruit-api     --timeout=120s
-          kubectl rollout status deployment/dagster-daemon    --timeout=180s || true
-          kubectl rollout status deployment/dagster-webserver --timeout=180s || true
+          kubectl rollout status deployment/dagster-daemon    --timeout=300s
+          kubectl rollout status deployment/dagster-webserver --timeout=300s
 
       - name: Rollback on failure
         if: failure() && steps.deploy.outcome != 'skipped'
-        run: kubectl rollout undo deployment/jackfruit-api
+        run: |
+          kubectl rollout undo deployment/jackfruit-api
+          kubectl rollout undo deployment/dagster-daemon
+          kubectl rollout undo deployment/dagster-webserver

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,6 @@ jobs:
       - name: Rollback on failure
         if: failure() && steps.deploy.outcome != 'skipped'
         run: |
-          kubectl rollout undo deployment/jackfruit-api
-          kubectl rollout undo deployment/dagster-daemon
-          kubectl rollout undo deployment/dagster-webserver
+          kubectl rollout undo deployment/jackfruit-api || true
+          kubectl rollout undo deployment/dagster-daemon || true
+          kubectl rollout undo deployment/dagster-webserver || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,95 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+env:
+  REGISTRY: rg.nl-ams.scw.cloud/climacterium
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set image tag
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Login to Scaleway Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: rg.nl-ams.scw.cloud
+          username: nologin
+          password: ${{ secrets.SCALEWAY_API_SECRET_KEY }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push jackfruit-api
+        uses: docker/build-push-action@v7
+        with:
+          context: ./serving-go
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ env.REGISTRY }}/jackfruit-api:${{ steps.vars.outputs.sha_short }}
+            ${{ env.REGISTRY }}/jackfruit-api:latest
+          cache-from: type=gha,scope=jackfruit-api
+          cache-to: type=gha,scope=jackfruit-api,mode=max
+
+      - name: Build and push pipeline-python
+        uses: docker/build-push-action@v7
+        with:
+          context: ./pipeline-python
+          push: true
+          platforms: linux/arm64
+          tags: |
+            ${{ env.REGISTRY }}/pipeline-python:${{ steps.vars.outputs.sha_short }}
+            ${{ env.REGISTRY }}/pipeline-python:latest
+          cache-from: type=gha,scope=pipeline-python
+          cache-to: type=gha,scope=pipeline-python,mode=max
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v5
+
+      - name: Configure kubeconfig
+        env:
+          KUBECONFIG_CONTENT: ${{ secrets.KUBECONFIG }}
+        run: |
+          mkdir -p ~/.kube
+          printenv KUBECONFIG_CONTENT > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Deploy to Kapsule
+        id: deploy
+        env:
+          SHA: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          kubectl set image deployment/jackfruit-api \
+            jackfruit-api=${REGISTRY}/jackfruit-api:${SHA}
+          kubectl set image deployment/dagster-daemon \
+            dagster-daemon=${REGISTRY}/pipeline-python:${SHA}
+          kubectl set image deployment/dagster-webserver \
+            dagster-webserver=${REGISTRY}/pipeline-python:${SHA}
+
+      - name: Wait for rollout
+        run: |
+          kubectl rollout status deployment/jackfruit-api     --timeout=120s
+          kubectl rollout status deployment/dagster-daemon    --timeout=180s || true
+          kubectl rollout status deployment/dagster-webserver --timeout=180s || true
+
+      - name: Rollback on failure
+        if: failure() && steps.deploy.outcome != 'skipped'
+        run: kubectl rollout undo deployment/jackfruit-api

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,17 @@ name: Test
 
 on:
   workflow_call:
+    inputs:
+      run-serving:
+        type: boolean
+        default: true
+      run-pipeline:
+        type: boolean
+        default: true
 
 jobs:
   test-serving-go:
+    if: ${{ inputs.run-serving }}
     runs-on: ubuntu-24.04-arm
     defaults:
       run:
@@ -15,7 +23,6 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: serving-go/go.mod
-          cache: true
 
       - name: Check formatting
         run: gofmt -l . | grep . && exit 1 || true
@@ -27,6 +34,7 @@ jobs:
         run: go test -short ./...
 
   test-pipeline-python:
+    if: ${{ inputs.run-pipeline }}
     runs-on: ubuntu-24.04-arm
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           go-version-file: serving-go/go.mod
 
       - name: Check formatting
-        run: gofmt -l . | grep . && exit 1 || true
+        run: test -z "$(gofmt -l .)"
 
       - name: Vet
         run: go vet ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Test
+
+on:
+  workflow_call:
+
+jobs:
+  test-serving-go:
+    runs-on: ubuntu-24.04-arm
+    defaults:
+      run:
+        working-directory: serving-go
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: serving-go/go.mod
+          cache: true
+
+      - name: Check formatting
+        run: gofmt -l . | grep . && exit 1 || true
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test (unit)
+        run: go test -short ./...
+
+  test-pipeline-python:
+    runs-on: ubuntu-24.04-arm
+    defaults:
+      run:
+        working-directory: pipeline-python
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Test (unit)
+        run: uv run pytest -m unit


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI/CD for the jackfruit sub-projects (serving-go + pipeline-python)
- PRs run lint (gofmt, go vet) and unit tests, with path-based filtering to skip unchanged sub-projects
- Pushes to main build ARM64 Docker images, push to Scaleway registry, and deploy to Kapsule with automatic rollback on failure

## Details
Three workflows:
- **test.yml** — reusable workflow with Go (fmt + vet + unit tests) and Python (uv + pytest) jobs, accepting boolean inputs to skip unchanged sub-projects
- **ci.yml** — PR gate that detects changed paths via `dorny/paths-filter` and calls test.yml conditionally
- **deploy.yml** — runs full test suite, builds + pushes ARM64 images to Scaleway Container Registry (GHA layer cache), deploys via `kubectl set image`, waits for rollout, rolls back all deployments on failure

## Required secrets
- `SCALEWAY_API_SECRET_KEY` — Scaleway Container Registry auth
- `KUBECONFIG` — Kapsule cluster kubeconfig

## Not yet covered
- Python linting (no ruff/mypy configured yet — separate follow-up)
- golangci-lint (to replace gofmt + go vet — separate follow-up)
- Integration tests in CI (would need service containers for ClickHouse + Postgres)