### PR TITLE
Fix out-of-coverage handling + nearest-neighbor perf (JF-BUG-01)

### DIFF
--- a/serving-go/internal/api/handler.go
+++ b/serving-go/internal/api/handler.go
@@ -48,10 +48,10 @@ func (h *Handler) handleEnvironmental(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if stale, ok := errors.AsType[*domain.ErrDataTooStale](err); ok {
 			writeError(w, http.StatusNotFound, stale.Error())
-		} else if errors.Is(err, domain.ErrTemporalMiss) {
-			writeError(w, http.StatusNotFound, "no data available at or before requested timestamp")
-		} else if errors.Is(err, domain.ErrSpatialMiss) {
-			writeError(w, http.StatusNotFound, "requested coordinates are outside data coverage")
+		} else if miss, ok := errors.AsType[*domain.ErrTemporalMiss](err); ok {
+			writeError(w, http.StatusNotFound, miss.Error())
+		} else if miss, ok := errors.AsType[*domain.ErrSpatialMiss](err); ok {
+			writeError(w, http.StatusNotFound, miss.Error())
 		} else if ctx.Err() != nil {
 			h.logger.Error("variableProvider.GetVariables timed out", "error", err)
 			writeError(w, http.StatusGatewayTimeout, "query timed out")

--- a/serving-go/internal/api/handler.go
+++ b/serving-go/internal/api/handler.go
@@ -46,8 +46,12 @@ func (h *Handler) handleEnvironmental(w http.ResponseWriter, r *http.Request) {
 		envReq.Variables,
 	)
 	if err != nil {
-		if notFound, ok := errors.AsType[*domain.ErrVariableNotFound](err); ok {
-			writeError(w, http.StatusNotFound, notFound.Error())
+		if stale, ok := errors.AsType[*domain.ErrDataTooStale](err); ok {
+			writeError(w, http.StatusNotFound, stale.Error())
+		} else if errors.Is(err, domain.ErrTemporalMiss) {
+			writeError(w, http.StatusNotFound, "no data available at or before requested timestamp")
+		} else if errors.Is(err, domain.ErrSpatialMiss) {
+			writeError(w, http.StatusNotFound, "requested coordinates are outside data coverage")
 		} else if ctx.Err() != nil {
 			h.logger.Error("variableProvider.GetVariables timed out", "error", err)
 			writeError(w, http.StatusGatewayTimeout, "query timed out")

--- a/serving-go/internal/api/handler_integration_test.go
+++ b/serving-go/internal/api/handler_integration_test.go
@@ -158,7 +158,7 @@ func TestEnvironmentalHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("variable not found", func(t *testing.T) {
+	t.Run("variable with no data is a temporal miss", func(t *testing.T) {
 		ts := time.Now().UTC().Truncate(time.Second)
 		url := fmt.Sprintf("/v1/environmental?lat=52.5&lon=13.4&timestamp=%s&variables=nonexistent_var",
 			ts.Format(time.RFC3339))
@@ -174,8 +174,8 @@ func TestEnvironmentalHandler(t *testing.T) {
 		if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
 			t.Fatalf("decode error response: %v", err)
 		}
-		if !strings.Contains(errResp.Error, "nonexistent_var") {
-			t.Errorf("expected error to mention variable name, got %q", errResp.Error)
+		if !strings.Contains(errResp.Error, "no data available") {
+			t.Errorf("expected temporal-miss error message, got %q", errResp.Error)
 		}
 	})
 

--- a/serving-go/internal/domain/environmental.go
+++ b/serving-go/internal/domain/environmental.go
@@ -2,7 +2,6 @@ package domain
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -10,12 +9,23 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type ErrVariableNotFound struct {
-	Variable string
+const maxTemporalGap = 24 * time.Hour
+
+type ErrDataTooStale struct {
+	Variable    string
+	RequestedAt time.Time
+	AvailableAt time.Time
+	Gap         time.Duration
 }
 
-func (e *ErrVariableNotFound) Error() string {
-	return fmt.Sprintf("variable %q not found", e.Variable)
+func (e *ErrDataTooStale) Error() string {
+	return fmt.Sprintf(
+		"variable %q: nearest data is %s old (requested %s, available %s)",
+		e.Variable,
+		e.Gap.Truncate(time.Minute),
+		e.RequestedAt.Format(time.RFC3339),
+		e.AvailableAt.Format(time.RFC3339),
+	)
 }
 
 type VariableResult struct {
@@ -73,11 +83,17 @@ func (s *Service) getVariable(
 	lat, lon float32,
 ) (*VariableResult, error) {
 	gridSample, err := s.grid.GetSample(ctx, variable, ts, lat, lon)
-	if errors.Is(err, ErrGridSampleNotFound) {
-		return nil, &ErrVariableNotFound{Variable: variable}
-	}
 	if err != nil {
 		return nil, fmt.Errorf("getting variable %q: %w", variable, err)
+	}
+
+	if gap := ts.Sub(gridSample.Timestamp); gap > maxTemporalGap {
+		return nil, &ErrDataTooStale{
+			Variable:    variable,
+			RequestedAt: ts,
+			AvailableAt: gridSample.Timestamp,
+			Gap:         gap,
+		}
 	}
 
 	lineage, err := s.lineage.GetLineage(ctx, gridSample.CatalogID)

--- a/serving-go/internal/domain/environmental_test.go
+++ b/serving-go/internal/domain/environmental_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,7 +28,7 @@ func (m *mockGridRetriever) GetSample(
 	}
 	sample := m.samples[variable]
 	if sample == nil {
-		return nil, ErrTemporalMiss
+		return nil, &ErrTemporalMiss{Variable: variable}
 	}
 
 	return sample, nil
@@ -36,11 +37,11 @@ func (m *mockGridRetriever) GetSample(
 type mockLineageRetriever struct {
 	lineages map[uuid.UUID]*Lineage
 	err      error
-	calls    int
+	calls    atomic.Int64
 }
 
 func (m *mockLineageRetriever) GetLineage(ctx context.Context, catalogID uuid.UUID) (*Lineage, error) {
-	m.calls++
+	m.calls.Add(1)
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -134,33 +135,41 @@ func TestService_GetVariables(t *testing.T) {
 func TestService_GetVariables_TemporalMiss(t *testing.T) {
 	lineageMock := &mockLineageRetriever{lineages: map[uuid.UUID]*Lineage{}}
 	service := NewService(&mockGridRetriever{
-		errs: map[string]error{"pm2p5": ErrTemporalMiss},
+		errs: map[string]error{"pm2p5": &ErrTemporalMiss{Variable: "pm2p5"}},
 	}, lineageMock)
 
 	_, err := service.GetVariables(t.Context(), time.Date(2026, 2, 27, 4, 0, 0, 0, time.UTC), 75.08, 106.29, []string{"pm2p5"})
-	if !errors.Is(err, ErrTemporalMiss) {
-		t.Errorf("expected error wrapping ErrTemporalMiss, got: %v", err)
+	miss, ok := errors.AsType[*ErrTemporalMiss](err)
+	if !ok {
+		t.Fatalf("expected *ErrTemporalMiss, got: %v", err)
+	}
+	if miss.Variable != "pm2p5" {
+		t.Errorf("expected Variable=pm2p5, got %q", miss.Variable)
 	}
 	if !strings.Contains(err.Error(), "pm2p5") {
-		t.Errorf("expected wrapped error to mention variable name, got: %q", err.Error())
+		t.Errorf("expected error message to mention variable name, got: %q", err.Error())
 	}
-	if lineageMock.calls != 0 {
-		t.Errorf("lineage must not be fetched on temporal miss, got %d calls", lineageMock.calls)
+	if got := lineageMock.calls.Load(); got != 0 {
+		t.Errorf("lineage must not be fetched on temporal miss, got %d calls", got)
 	}
 }
 
 func TestService_GetVariables_SpatialMiss(t *testing.T) {
 	lineageMock := &mockLineageRetriever{lineages: map[uuid.UUID]*Lineage{}}
 	service := NewService(&mockGridRetriever{
-		errs: map[string]error{"pm2p5": ErrSpatialMiss},
+		errs: map[string]error{"pm2p5": &ErrSpatialMiss{Variable: "pm2p5"}},
 	}, lineageMock)
 
 	_, err := service.GetVariables(t.Context(), time.Date(2026, 2, 27, 4, 0, 0, 0, time.UTC), 75.08, 106.29, []string{"pm2p5"})
-	if !errors.Is(err, ErrSpatialMiss) {
-		t.Errorf("expected error wrapping ErrSpatialMiss, got: %v", err)
+	miss, ok := errors.AsType[*ErrSpatialMiss](err)
+	if !ok {
+		t.Fatalf("expected *ErrSpatialMiss, got: %v", err)
 	}
-	if lineageMock.calls != 0 {
-		t.Errorf("lineage must not be fetched on spatial miss, got %d calls", lineageMock.calls)
+	if miss.Variable != "pm2p5" {
+		t.Errorf("expected Variable=pm2p5, got %q", miss.Variable)
+	}
+	if got := lineageMock.calls.Load(); got != 0 {
+		t.Errorf("lineage must not be fetched on spatial miss, got %d calls", got)
 	}
 }
 
@@ -196,8 +205,8 @@ func TestService_GetVariables_DataTooStale(t *testing.T) {
 	if stale.Gap != maxTemporalGap+time.Minute {
 		t.Errorf("expected Gap=%v, got %v", maxTemporalGap+time.Minute, stale.Gap)
 	}
-	if lineageMock.calls != 0 {
-		t.Errorf("lineage must not be fetched when data is stale, got %d calls", lineageMock.calls)
+	if got := lineageMock.calls.Load(); got != 0 {
+		t.Errorf("lineage must not be fetched when data is stale, got %d calls", got)
 	}
 }
 

--- a/serving-go/internal/domain/environmental_test.go
+++ b/serving-go/internal/domain/environmental_test.go
@@ -12,6 +12,7 @@ import (
 
 type mockGridRetriever struct {
 	samples map[string]*GridSample
+	errs    map[string]error
 }
 
 func (m *mockGridRetriever) GetSample(
@@ -21,9 +22,12 @@ func (m *mockGridRetriever) GetSample(
 	lat float32,
 	lon float32,
 ) (*GridSample, error) {
+	if err, ok := m.errs[variable]; ok {
+		return nil, err
+	}
 	sample := m.samples[variable]
 	if sample == nil {
-		return nil, ErrGridSampleNotFound
+		return nil, ErrTemporalMiss
 	}
 
 	return sample, nil
@@ -32,9 +36,11 @@ func (m *mockGridRetriever) GetSample(
 type mockLineageRetriever struct {
 	lineages map[uuid.UUID]*Lineage
 	err      error
+	calls    int
 }
 
 func (m *mockLineageRetriever) GetLineage(ctx context.Context, catalogID uuid.UUID) (*Lineage, error) {
+	m.calls++
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -125,32 +131,101 @@ func TestService_GetVariables(t *testing.T) {
 	}
 }
 
-func TestService_GetVariables_NotFound(t *testing.T) {
-	existingVariable := "pm10"
+func TestService_GetVariables_TemporalMiss(t *testing.T) {
+	lineageMock := &mockLineageRetriever{lineages: map[uuid.UUID]*Lineage{}}
+	service := NewService(&mockGridRetriever{
+		errs: map[string]error{"pm2p5": ErrTemporalMiss},
+	}, lineageMock)
 
-	variableName := "pm2p5"
-	timestamp := time.Date(2026, 2, 27, 4, 0, 0, 0, time.UTC)
-	lat := float32(75.08)
-	lon := float32(106.29)
+	_, err := service.GetVariables(t.Context(), time.Date(2026, 2, 27, 4, 0, 0, 0, time.UTC), 75.08, 106.29, []string{"pm2p5"})
+	if !errors.Is(err, ErrTemporalMiss) {
+		t.Errorf("expected error wrapping ErrTemporalMiss, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "pm2p5") {
+		t.Errorf("expected wrapped error to mention variable name, got: %q", err.Error())
+	}
+	if lineageMock.calls != 0 {
+		t.Errorf("lineage must not be fetched on temporal miss, got %d calls", lineageMock.calls)
+	}
+}
 
-	existingCatalogID, err := uuid.NewV7()
+func TestService_GetVariables_SpatialMiss(t *testing.T) {
+	lineageMock := &mockLineageRetriever{lineages: map[uuid.UUID]*Lineage{}}
+	service := NewService(&mockGridRetriever{
+		errs: map[string]error{"pm2p5": ErrSpatialMiss},
+	}, lineageMock)
+
+	_, err := service.GetVariables(t.Context(), time.Date(2026, 2, 27, 4, 0, 0, 0, time.UTC), 75.08, 106.29, []string{"pm2p5"})
+	if !errors.Is(err, ErrSpatialMiss) {
+		t.Errorf("expected error wrapping ErrSpatialMiss, got: %v", err)
+	}
+	if lineageMock.calls != 0 {
+		t.Errorf("lineage must not be fetched on spatial miss, got %d calls", lineageMock.calls)
+	}
+}
+
+func TestService_GetVariables_DataTooStale(t *testing.T) {
+	requestedTS := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	availableTS := requestedTS.Add(-(maxTemporalGap + time.Minute))
+
+	catalogID, err := uuid.NewV7()
 	if err != nil {
 		t.Fatal(err)
 	}
-	service := NewService(&mockGridRetriever{samples: map[string]*GridSample{
-		existingVariable: {Value: 1.0, Unit: "µg/m³", Lat: 75.05, Lon: 106.25, Timestamp: time.Date(2026, 2, 27, 4, 0, 0, 0, time.UTC), CatalogID: existingCatalogID},
-	}}, &mockLineageRetriever{lineages: map[uuid.UUID]*Lineage{}})
+	lineageMock := &mockLineageRetriever{lineages: map[uuid.UUID]*Lineage{}}
+	service := NewService(&mockGridRetriever{
+		samples: map[string]*GridSample{
+			"pm2p5": {Value: 12.5, Unit: "µg/m³", Lat: 52.5, Lon: 13.4, Timestamp: availableTS, CatalogID: catalogID},
+		},
+	}, lineageMock)
 
-	_, err = service.GetVariables(t.Context(), timestamp, lat, lon, []string{existingVariable, variableName})
-	targetError, ok := errors.AsType[*ErrVariableNotFound](err)
+	_, err = service.GetVariables(t.Context(), requestedTS, 52.5, 13.4, []string{"pm2p5"})
+	stale, ok := errors.AsType[*ErrDataTooStale](err)
 	if !ok {
-		t.Errorf("GetVariables returned wrong error: %v", err)
+		t.Fatalf("expected *ErrDataTooStale, got: %v", err)
 	}
-	if targetError.Variable != variableName {
-		t.Errorf("GetVariables returned wrong variable: %v", targetError.Variable)
+	if stale.Variable != "pm2p5" {
+		t.Errorf("expected Variable=pm2p5, got %q", stale.Variable)
 	}
-	if !strings.Contains(err.Error(), "pm2p5") {
-		t.Errorf("ErrVariableNotFound message should contain variable pm2p5, actual message: %q", err.Error())
+	if !stale.RequestedAt.Equal(requestedTS) {
+		t.Errorf("expected RequestedAt=%v, got %v", requestedTS, stale.RequestedAt)
+	}
+	if !stale.AvailableAt.Equal(availableTS) {
+		t.Errorf("expected AvailableAt=%v, got %v", availableTS, stale.AvailableAt)
+	}
+	if stale.Gap != maxTemporalGap+time.Minute {
+		t.Errorf("expected Gap=%v, got %v", maxTemporalGap+time.Minute, stale.Gap)
+	}
+	if lineageMock.calls != 0 {
+		t.Errorf("lineage must not be fetched when data is stale, got %d calls", lineageMock.calls)
+	}
+}
+
+func TestService_GetVariables_DataAtTemporalBoundary(t *testing.T) {
+	requestedTS := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	availableTS := requestedTS.Add(-maxTemporalGap)
+
+	catalogID, err := uuid.NewV7()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawFileID, err := uuid.NewV7()
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewService(&mockGridRetriever{
+		samples: map[string]*GridSample{
+			"pm2p5": {Value: 12.5, Unit: "µg/m³", Lat: 52.5, Lon: 13.4, Timestamp: availableTS, CatalogID: catalogID},
+		},
+	}, &mockLineageRetriever{
+		lineages: map[uuid.UUID]*Lineage{
+			catalogID: {Source: "ads", Dataset: "cams-europe-air-quality-forecast", RawFileID: rawFileID},
+		},
+	})
+
+	_, err = service.GetVariables(t.Context(), requestedTS, 52.5, 13.4, []string{"pm2p5"})
+	if err != nil {
+		t.Errorf("expected no error at boundary (gap == maxTemporalGap), got: %v", err)
 	}
 }
 

--- a/serving-go/internal/domain/grid.go
+++ b/serving-go/internal/domain/grid.go
@@ -8,7 +8,10 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrGridSampleNotFound = errors.New("grid sample not found")
+var (
+	ErrTemporalMiss = errors.New("no data at or before requested timestamp")
+	ErrSpatialMiss  = errors.New("no grid point within spatial bounds")
+)
 
 type GridSample struct {
 	Value     float32

--- a/serving-go/internal/domain/grid.go
+++ b/serving-go/internal/domain/grid.go
@@ -2,16 +2,27 @@ package domain
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 )
 
-var (
-	ErrTemporalMiss = errors.New("no data at or before requested timestamp")
-	ErrSpatialMiss  = errors.New("no grid point within spatial bounds")
-)
+type ErrTemporalMiss struct {
+	Variable string
+}
+
+func (e *ErrTemporalMiss) Error() string {
+	return fmt.Sprintf("variable %q: no data available at or before requested timestamp", e.Variable)
+}
+
+type ErrSpatialMiss struct {
+	Variable string
+}
+
+func (e *ErrSpatialMiss) Error() string {
+	return fmt.Sprintf("variable %q: requested coordinates are outside data coverage", e.Variable)
+}
 
 type GridSample struct {
 	Value     float32

--- a/serving-go/internal/grid/finder.go
+++ b/serving-go/internal/grid/finder.go
@@ -13,6 +13,8 @@ import (
 	"github.com/kacper-wojtaszczyk/jackfruit/serving-go/internal/domain"
 )
 
+const spatialBoxDeg = 0.3
+
 type Finder struct {
 	conn driver.Conn
 }
@@ -28,32 +30,51 @@ func (c *Finder) GetSample(
 	lat float32,
 	lon float32,
 ) (*domain.GridSample, error) {
-	var result domain.GridSample
+	const resolveTimestampQuery = `
+        SELECT maxOrNull(timestamp)
+        FROM grid_data FINAL
+        WHERE variable = @variable AND timestamp <= @timestamp
+    `
+	var resolvedTS *time.Time
 	err := c.conn.QueryRow(
 		ctx,
-		`
+		resolveTimestampQuery,
+		clickhouse.Named("variable", variable),
+		clickhouse.Named("timestamp", timestamp),
+	).Scan(&resolvedTS)
+	if err != nil {
+		return nil, fmt.Errorf("resolve timestamp: %w", err)
+	}
+	if resolvedTS == nil {
+		return nil, domain.ErrTemporalMiss
+	}
+
+	const spatialLookupQuery = `
         SELECT value, unit, lat, lon, catalog_id, timestamp
         FROM grid_data FINAL
         WHERE variable = @variable
-          AND timestamp = (
-            SELECT max(timestamp) FROM grid_data FINAL
-            WHERE variable = @variable AND timestamp <= @timestamp
-          )
+          AND timestamp = @timestamp
+          AND lat BETWEEN @lat - @tol AND @lat + @tol
+          AND lon BETWEEN @lon - @tol AND @lon + @tol
         ORDER BY (lat - @lat) * (lat - @lat) + (lon - @lon) * (lon - @lon)
         LIMIT 1
-        `,
+    `
+	var result domain.GridSample
+	err = c.conn.QueryRow(
+		ctx,
+		spatialLookupQuery,
 		clickhouse.Named("variable", variable),
-		clickhouse.Named("timestamp", timestamp),
+		clickhouse.Named("timestamp", *resolvedTS),
 		clickhouse.Named("lat", lat),
 		clickhouse.Named("lon", lon),
+		clickhouse.Named("tol", float32(spatialBoxDeg)),
 	).Scan(&result.Value, &result.Unit, &result.Lat, &result.Lon, &result.CatalogID, &result.Timestamp)
 
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, domain.ErrGridSampleNotFound
+		return nil, domain.ErrSpatialMiss
 	}
-
 	if err != nil {
-		return nil, fmt.Errorf("query clickhouse: %w", err)
+		return nil, fmt.Errorf("spatial lookup: %w", err)
 	}
 
 	return &result, nil

--- a/serving-go/internal/grid/finder.go
+++ b/serving-go/internal/grid/finder.go
@@ -13,6 +13,12 @@ import (
 	"github.com/kacper-wojtaszczyk/jackfruit/serving-go/internal/domain"
 )
 
+// spatialBoxDeg must be >= the half-diagonal of the coarsest grid cell so the
+// nearest grid point is always inside the bounding box — otherwise a query
+// exactly between four grid points would miss all of them and yield a false
+// ErrSpatialMiss. Coarsest current grid is ECMWF at 0.25° → half-diagonal
+// 0.125 * sqrt(2) ≈ 0.177°. 0.3° gives ~70% headroom; widen or make
+// per-source if a coarser data source is added.
 const spatialBoxDeg = 0.3
 
 type Finder struct {
@@ -30,9 +36,12 @@ func (c *Finder) GetSample(
 	lat float32,
 	lon float32,
 ) (*domain.GridSample, error) {
+	// FINAL is intentionally omitted: max(timestamp) is invariant to
+	// ReplacingMergeTree duplicates because they share the ORDER BY key
+	// (variable, timestamp, lat, lon), so duplicates agree on timestamp.
 	const resolveTimestampQuery = `
         SELECT maxOrNull(timestamp)
-        FROM grid_data FINAL
+        FROM grid_data
         WHERE variable = @variable AND timestamp <= @timestamp
     `
 	var resolvedTS *time.Time
@@ -46,9 +55,11 @@ func (c *Finder) GetSample(
 		return nil, fmt.Errorf("resolve timestamp: %w", err)
 	}
 	if resolvedTS == nil {
-		return nil, domain.ErrTemporalMiss
+		return nil, &domain.ErrTemporalMiss{Variable: variable}
 	}
 
+	// FINAL required here: value and catalog_id differ between unmerged
+	// duplicates, so we need the replaced row.
 	const spatialLookupQuery = `
         SELECT value, unit, lat, lon, catalog_id, timestamp
         FROM grid_data FINAL
@@ -71,7 +82,7 @@ func (c *Finder) GetSample(
 	).Scan(&result.Value, &result.Unit, &result.Lat, &result.Lon, &result.CatalogID, &result.Timestamp)
 
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, domain.ErrSpatialMiss
+		return nil, &domain.ErrSpatialMiss{Variable: variable}
 	}
 	if err != nil {
 		return nil, fmt.Errorf("spatial lookup: %w", err)

--- a/serving-go/internal/grid/finder_integration_test.go
+++ b/serving-go/internal/grid/finder_integration_test.go
@@ -61,8 +61,12 @@ func TestGetSample_TemporalMiss(t *testing.T) {
 	}
 
 	_, err := grid.NewFinder(testutil.NewRawConn(t)).GetSample(t.Context(), "nonexistent_variable", time.Now().UTC().Truncate(time.Second), 0, 0)
-	if !errors.Is(err, domain.ErrTemporalMiss) {
-		t.Errorf("expected ErrTemporalMiss, got %v", err)
+	miss, ok := errors.AsType[*domain.ErrTemporalMiss](err)
+	if !ok {
+		t.Fatalf("expected *ErrTemporalMiss, got %v", err)
+	}
+	if miss.Variable != "nonexistent_variable" {
+		t.Errorf("expected Variable=nonexistent_variable, got %q", miss.Variable)
 	}
 }
 
@@ -79,7 +83,11 @@ func TestGetSample_SpatialMiss(t *testing.T) {
 	testutil.InsertGridRow(t, rawConn, variable, float32(1.0), "µg/m³", timestamp, float32(50.0), float32(10.0))
 
 	_, err := grid.NewFinder(rawConn).GetSample(ctx, variable, timestamp, float32(0.0), float32(0.0))
-	if !errors.Is(err, domain.ErrSpatialMiss) {
-		t.Errorf("expected ErrSpatialMiss, got %v", err)
+	miss, ok := errors.AsType[*domain.ErrSpatialMiss](err)
+	if !ok {
+		t.Fatalf("expected *ErrSpatialMiss, got %v", err)
+	}
+	if miss.Variable != variable {
+		t.Errorf("expected Variable=%q, got %q", variable, miss.Variable)
 	}
 }

--- a/serving-go/internal/grid/finder_integration_test.go
+++ b/serving-go/internal/grid/finder_integration_test.go
@@ -30,7 +30,7 @@ func TestGetSample(t *testing.T) {
 
 	client := grid.NewFinder(rawConn)
 
-	gridSample, err := client.GetSample(ctx, variable, timestamp.Add(30*time.Minute), lat+0.435, lon+0.195)
+	gridSample, err := client.GetSample(ctx, variable, timestamp.Add(30*time.Minute), lat+0.2, lon+0.1)
 	if err != nil {
 		t.Fatalf("GetSample returned error: %v", err)
 	}
@@ -55,13 +55,31 @@ func TestGetSample(t *testing.T) {
 	}
 }
 
-func TestGetSampleNotFound(t *testing.T) {
+func TestGetSample_TemporalMiss(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test, requires ClickHouse")
 	}
 
-	_, err := grid.NewFinder(testutil.NewRawConn(t)).GetSample(t.Context(), "nonexistent_variable", time.Now(), 0, 0)
-	if !errors.Is(err, domain.ErrGridSampleNotFound) {
-		t.Errorf("expected ErrGridSampleNotFound, got %v", err)
+	_, err := grid.NewFinder(testutil.NewRawConn(t)).GetSample(t.Context(), "nonexistent_variable", time.Now().UTC().Truncate(time.Second), 0, 0)
+	if !errors.Is(err, domain.ErrTemporalMiss) {
+		t.Errorf("expected ErrTemporalMiss, got %v", err)
+	}
+}
+
+func TestGetSample_SpatialMiss(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test, requires ClickHouse")
+	}
+
+	ctx := t.Context()
+	rawConn := testutil.NewRawConn(t)
+
+	variable := "pm2p5_spatial_miss"
+	timestamp := time.Now().UTC().Truncate(time.Second)
+	testutil.InsertGridRow(t, rawConn, variable, float32(1.0), "µg/m³", timestamp, float32(50.0), float32(10.0))
+
+	_, err := grid.NewFinder(rawConn).GetSample(ctx, variable, timestamp, float32(0.0), float32(0.0))
+	if !errors.Is(err, domain.ErrSpatialMiss) {
+		t.Errorf("expected ErrSpatialMiss, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- `/v1/environmental` now returns **404** when the requested coords are outside spatial
  coverage, or when the nearest available timestamp is older than `maxTemporalGap` (24h).
  Previously it silently snapped to the nearest edge grid point (potentially 2000+ km
  away) or the last available forecast (potentially days old) and returned 200.
- The nearest-neighbor query is split into two steps: timestamp resolution, then a
  bounded spatial lookup using the ClickHouse primary-index ordering
  `(variable, timestamp, lat, lon)`. This removes the full-partition sort that was
  driving ~5s response times for 5-variable requests.
- Introduces three domain errors — `ErrTemporalMiss`, `ErrSpatialMiss`,
  `*ErrDataTooStale` — and deletes the now-redundant `ErrGridSampleNotFound` and
  `*ErrVariableNotFound`. `*ErrDataTooStale` carries `RequestedAt` / `AvailableAt` /
  `Gap` so the handler can surface useful context in the 404 body.

## Mechanism

1. **Step 1 — resolve timestamp.** `SELECT maxOrNull(timestamp) FROM grid_data FINAL
   WHERE variable = @v AND timestamp <= @t`. NULL → `ErrTemporalMiss`. Uses
   `maxOrNull` (not `max`) because `max()` on a non-nullable `DateTime` column returns
   a zero value on empty input, not NULL, which would look like a valid 1970 match.
2. **Step 2 — bounded spatial lookup.** Adds
   `lat BETWEEN @lat - 0.3 AND @lat + 0.3` (same for lon) to the spatial sort. The
   0.3° box covers the half-diagonal of a 0.25° grid cell with ~70% headroom. No rows
   in the box → `ErrSpatialMiss`. The bounding box doubles as the spatial tolerance
   check, so new coverage areas extend automatically — no code change needed.
3. **Step 3 — domain-level staleness check.** In `getVariable`, compare the returned
   sample's timestamp against the request. `gap > maxTemporalGap` → `*ErrDataTooStale`.
   Runs before the Postgres lineage lookup so rejected samples don't incur a round-trip.

## Test plan

- [x] Unit tests: `go test -short ./...` (new cases cover temporal miss, spatial
      miss, stale data, boundary at exactly `maxTemporalGap`, and lineage-not-called
      invariants on all three failure paths)
- [x] Integration tests: `go test ./...` against ClickHouse + Postgres (adds
      `TestGetSample_TemporalMiss` and `TestGetSample_SpatialMiss`, removes the
      obsolete `TestGetSampleNotFound`)
- [x] Manual smoke: hit `/v1/environmental` with
  - European coords + recent timestamp → 200 with sample
  - Sahara coords (outside CAMS/ECMWF Europe coverage) → 404 "requested coordinates are outside data coverage"
  - European coords + timestamp 1 week in the future → 404 with `ErrDataTooStale` message including the gap
  - European coords + timestamp in 1950 → 404 "no data available at or before requested timestamp"
- [ ] Eyeball p95 latency for a 5-variable request — target is **<500ms**
      (previously ~5s). Not yet asserted by an automated benchmark. (after deploy)