### PR TITLE
Add panic recovery + request logging middleware to jackfruit (JF-02)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -134,7 +134,7 @@ One query per variable, fetched in parallel. `grid_data` has no `source` column 
 
 Env vars: `PORT`, `CLICKHOUSE_HOST`, `CLICKHOUSE_NATIVE_PORT`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`, `CLICKHOUSE_DATABASE`, `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`.
 
-Server timeouts: read 5s, write 10s, idle 60s. Graceful shutdown on SIGINT/SIGTERM (5s timeout).
+Server timeouts: read 5s, write 20s, idle 60s. The handler enforces an 18s inner deadline via `context.WithTimeout`; the 20s `WriteTimeout` leaves ~2s slack for serializing the 504 body. Graceful shutdown on SIGINT/SIGTERM (5s timeout).
 
 ### Conventions
 

--- a/serving-go/cmd/serving/main.go
+++ b/serving-go/cmd/serving/main.go
@@ -80,12 +80,12 @@ func newApp() (*app, error) {
 	service := domain.NewService(chFinder, lineageFinder)
 
 	mux := http.NewServeMux()
-
-	var h http.Handler = mux
-	h = api.LoggingMiddleware(logger.With("component", "http"))(h)
-	h = api.RecoveryMiddleware(logger.With("component", "http"))(h)
-
 	api.NewHandler(service, logger.With("component", "api")).RegisterRoutes(mux)
+
+	httpLogger := logger.With("component", "http")
+	var h http.Handler = mux
+	h = api.LoggingMiddleware(httpLogger)(h)
+	h = api.RecoveryMiddleware(httpLogger)(h)
 
 	server := &http.Server{
 		Addr:         ":" + cfg.Port,

--- a/serving-go/cmd/serving/main.go
+++ b/serving-go/cmd/serving/main.go
@@ -80,11 +80,16 @@ func newApp() (*app, error) {
 	service := domain.NewService(chFinder, lineageFinder)
 
 	mux := http.NewServeMux()
+
+	var h http.Handler = mux
+	h = api.LoggingMiddleware(logger.With("component", "http"))(h)
+	h = api.RecoveryMiddleware(logger.With("component", "http"))(h)
+
 	api.NewHandler(service, logger.With("component", "api")).RegisterRoutes(mux)
 
 	server := &http.Server{
 		Addr:         ":" + cfg.Port,
-		Handler:      mux,
+		Handler:      h,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 20 * time.Second,
 		IdleTimeout:  60 * time.Second,

--- a/serving-go/internal/api/handler.go
+++ b/serving-go/internal/api/handler.go
@@ -46,14 +46,16 @@ func (h *Handler) handleEnvironmental(w http.ResponseWriter, r *http.Request) {
 		envReq.Variables,
 	)
 	if err != nil {
-		if notFound, ok := errors.AsType[*domain.ErrVariableNotFound](err); ok {
+		notFound, isNotFound := errors.AsType[*domain.ErrVariableNotFound](err)
+		switch {
+		case isNotFound:
 			writeError(w, http.StatusNotFound, notFound.Error())
-		} else if errors.Is(err, context.DeadlineExceeded) {
+		case errors.Is(err, context.DeadlineExceeded):
 			h.logger.Error("variableProvider.GetVariables timed out", "error", err)
 			writeError(w, http.StatusGatewayTimeout, "query timed out")
-		} else if errors.Is(err, context.Canceled) {
+		case errors.Is(err, context.Canceled):
 			h.logger.Info("client gone", "error", err)
-		} else {
+		default:
 			h.logger.Error("variableProvider.GetVariables failed", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 		}

--- a/serving-go/internal/api/handler.go
+++ b/serving-go/internal/api/handler.go
@@ -48,11 +48,11 @@ func (h *Handler) handleEnvironmental(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if notFound, ok := errors.AsType[*domain.ErrVariableNotFound](err); ok {
 			writeError(w, http.StatusNotFound, notFound.Error())
-		} else if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			h.logger.Error("variableProvider.GetVariables timed out", "error", ctx.Err())
+		} else if errors.Is(err, context.DeadlineExceeded) {
+			h.logger.Error("variableProvider.GetVariables timed out", "error", err)
 			writeError(w, http.StatusGatewayTimeout, "query timed out")
-		} else if errors.Is(ctx.Err(), context.Canceled) {
-			h.logger.Info("client gone", "error", ctx.Err())
+		} else if errors.Is(err, context.Canceled) {
+			h.logger.Info("client gone", "error", err)
 		} else {
 			h.logger.Error("variableProvider.GetVariables failed", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")

--- a/serving-go/internal/api/handler.go
+++ b/serving-go/internal/api/handler.go
@@ -48,9 +48,11 @@ func (h *Handler) handleEnvironmental(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if notFound, ok := errors.AsType[*domain.ErrVariableNotFound](err); ok {
 			writeError(w, http.StatusNotFound, notFound.Error())
-		} else if ctx.Err() != nil {
-			h.logger.Error("variableProvider.GetVariables timed out", "error", err)
+		} else if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			h.logger.Error("variableProvider.GetVariables timed out", "error", ctx.Err())
 			writeError(w, http.StatusGatewayTimeout, "query timed out")
+		} else if errors.Is(ctx.Err(), context.Canceled) {
+			h.logger.Info("client gone", "error", ctx.Err())
 		} else {
 			h.logger.Error("variableProvider.GetVariables failed", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")

--- a/serving-go/internal/api/handler.go
+++ b/serving-go/internal/api/handler.go
@@ -50,13 +50,13 @@ func (h *Handler) handleEnvironmental(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, notFound.Error())
 			return
 		}
+		if errors.Is(r.Context().Err(), context.Canceled) {
+			h.logger.Info("client gone", "error", err)
+			return
+		}
 		if errors.Is(err, context.DeadlineExceeded) {
 			h.logger.Error("variableProvider.GetVariables timed out", "error", err)
 			writeError(w, http.StatusGatewayTimeout, "query timed out")
-			return
-		}
-		if errors.Is(err, context.Canceled) {
-			h.logger.Info("client gone", "error", err)
 			return
 		}
 		h.logger.Error("variableProvider.GetVariables failed", "error", err)

--- a/serving-go/internal/api/handler.go
+++ b/serving-go/internal/api/handler.go
@@ -46,19 +46,21 @@ func (h *Handler) handleEnvironmental(w http.ResponseWriter, r *http.Request) {
 		envReq.Variables,
 	)
 	if err != nil {
-		notFound, isNotFound := errors.AsType[*domain.ErrVariableNotFound](err)
-		switch {
-		case isNotFound:
+		if notFound, ok := errors.AsType[*domain.ErrVariableNotFound](err); ok {
 			writeError(w, http.StatusNotFound, notFound.Error())
-		case errors.Is(err, context.DeadlineExceeded):
+			return
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
 			h.logger.Error("variableProvider.GetVariables timed out", "error", err)
 			writeError(w, http.StatusGatewayTimeout, "query timed out")
-		case errors.Is(err, context.Canceled):
-			h.logger.Info("client gone", "error", err)
-		default:
-			h.logger.Error("variableProvider.GetVariables failed", "error", err)
-			writeError(w, http.StatusInternalServerError, "internal server error")
+			return
 		}
+		if errors.Is(err, context.Canceled) {
+			h.logger.Info("client gone", "error", err)
+			return
+		}
+		h.logger.Error("variableProvider.GetVariables failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
 		return
 	}
 

--- a/serving-go/internal/api/handler_test.go
+++ b/serving-go/internal/api/handler_test.go
@@ -2,6 +2,7 @@ package api_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -16,9 +17,16 @@ import (
 
 type mockVariableProvider struct {
 	err error
+	// When true, GetVariables blocks until the context is done and
+	// returns ctx.Err(). Used by the cancel/deadline tests below.
+	blockUntilCtxDone bool
 }
 
-func (m *mockVariableProvider) GetVariables(_ context.Context, _ time.Time, _ float32, _ float32, _ []string) ([]domain.VariableResult, error) {
+func (m *mockVariableProvider) GetVariables(ctx context.Context, _ time.Time, _ float32, _ float32, _ []string) ([]domain.VariableResult, error) {
+	if m.blockUntilCtxDone {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
 	return nil, m.err
 }
 
@@ -43,5 +51,65 @@ func TestHandleEnvironmental_InternalError(t *testing.T) {
 	}
 	if !strings.Contains(body, "internal server error") {
 		t.Errorf("response body must contain 'internal server error', got: %s", body)
+	}
+}
+
+// When the client disconnects mid-flight, the handler must not write
+// anything — the connection is gone. Asserting an empty body is the
+// only verifiable contract here (httptest.ResponseRecorder defaults
+// Code to 200 even when no WriteHeader is ever called).
+func TestHandleEnvironmental_ClientCanceled_NoBody(t *testing.T) {
+	mock := &mockVariableProvider{blockUntilCtxDone: true}
+	logger := slog.New(slog.DiscardHandler)
+
+	mux := http.NewServeMux()
+	api.NewHandler(mock, logger).RegisterRoutes(mux)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so the mock returns context.Canceled immediately
+
+	req := httptest.NewRequest("GET", "/v1/environmental?lat=52.5&lon=13.4&timestamp=2025-03-11T00:00:00Z&variables=pm2p5", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Body.Len() != 0 {
+		t.Errorf("expected empty body for cancelled client, got: %q", w.Body.String())
+	}
+	if got := w.Header().Get("Content-Type"); got != "" {
+		t.Errorf("expected no Content-Type for cancelled client, got: %q", got)
+	}
+}
+
+// When the upstream takes too long (deadline exceeded), the handler
+// must convert that into a 504, not a 500 or a silent drop.
+func TestHandleEnvironmental_DeadlineExceeded_Returns504(t *testing.T) {
+	mock := &mockVariableProvider{blockUntilCtxDone: true}
+	logger := slog.New(slog.DiscardHandler)
+
+	mux := http.NewServeMux()
+	api.NewHandler(mock, logger).RegisterRoutes(mux)
+
+	// Parent deadline already in the past. The handler's inner
+	// context.WithTimeout(parent, 18s) inherits this earlier deadline,
+	// so ctx.Err() resolves to context.DeadlineExceeded immediately.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	req := httptest.NewRequest("GET", "/v1/environmental?lat=52.5&lon=13.4&timestamp=2025-03-11T00:00:00Z&variables=pm2p5", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusGatewayTimeout {
+		t.Errorf("expected status 504, got %d (body=%q)", w.Code, w.Body.String())
+	}
+
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("decode body: %v (body=%q)", err, w.Body.String())
+	}
+	if errResp.Error != "query timed out" {
+		t.Errorf("error message = %q, want %q", errResp.Error, "query timed out")
 	}
 }

--- a/serving-go/internal/api/middleware.go
+++ b/serving-go/internal/api/middleware.go
@@ -39,7 +39,7 @@ func RecoveryMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 						"path", r.URL.RequestURI(),
 					)
 					if !rec.written {
-						writeError(w, http.StatusInternalServerError, "internal server error")
+						writeError(rec, http.StatusInternalServerError, "internal server error")
 					}
 					// If headers were already sent, the response is
 					// already in-flight — log and let the connection

--- a/serving-go/internal/api/middleware.go
+++ b/serving-go/internal/api/middleware.go
@@ -36,7 +36,7 @@ func RecoveryMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 						"error", err,
 						"stack", string(debug.Stack()),
 						"method", r.Method,
-						"path", r.URL.Path,
+						"path", r.URL.RequestURI(),
 					)
 					if !rec.written {
 						writeError(w, http.StatusInternalServerError, "internal server error")
@@ -98,7 +98,7 @@ func LoggingMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 			// already defaults to 200 on bare Write([]byte) calls.
 			logger.Info("request",
 				"method", r.Method,
-				"path", r.URL.Path,
+				"path", r.URL.RequestURI(),
 				"status", wrapped.status,
 				"duration", time.Since(start),
 				"client", client,

--- a/serving-go/internal/api/middleware.go
+++ b/serving-go/internal/api/middleware.go
@@ -36,7 +36,7 @@ func RecoveryMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 						"error", err,
 						"stack", string(debug.Stack()),
 						"method", r.Method,
-						"path", r.URL.RequestURI(),
+						"path", r.URL.Path,
 					)
 					if !rec.written {
 						writeError(w, http.StatusInternalServerError, "internal server error")
@@ -87,20 +87,19 @@ func LoggingMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
 				return
 			}
 
-			status := wrapped.status
-			if status == 0 {
-				status = http.StatusOK
-			}
-
 			client := r.UserAgent()
 			if client == "" {
 				client = "unknown"
 			}
 
+			// status stays 0 if the handler returned without writing
+			// anything (e.g. client-disconnect path). Logging 0 keeps
+			// disconnects distinguishable from real 200s; statusRecorder
+			// already defaults to 200 on bare Write([]byte) calls.
 			logger.Info("request",
 				"method", r.Method,
-				"path", r.URL.RequestURI(),
-				"status", status,
+				"path", r.URL.Path,
+				"status", wrapped.status,
 				"duration", time.Since(start),
 				"client", client,
 			)

--- a/serving-go/internal/api/middleware.go
+++ b/serving-go/internal/api/middleware.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+	"time"
+)
+
+type recoverWriter struct {
+	http.ResponseWriter
+	written bool
+}
+
+func (rw *recoverWriter) WriteHeader(code int) {
+	rw.written = true
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *recoverWriter) Write(b []byte) (int, error) {
+	rw.written = true
+	return rw.ResponseWriter.Write(b)
+}
+
+func (rw *recoverWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
+}
+
+func RecoveryMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			rec := &recoverWriter{ResponseWriter: w}
+			defer func() {
+				if err := recover(); err != nil {
+					logger.Error("panic recovered",
+						"error", err,
+						"stack", string(debug.Stack()),
+						"method", r.Method,
+						"path", r.URL.RequestURI(),
+					)
+					if !rec.written {
+						writeError(w, http.StatusInternalServerError, "internal server error")
+					}
+					// If headers were already sent, the response is
+					// already in-flight — log and let the connection
+					// close with a truncated body.
+				}
+			}()
+			next.ServeHTTP(rec, r)
+		})
+	}
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	return r.ResponseWriter.Write(b)
+}
+
+func (r *statusRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
+}
+
+func LoggingMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			wrapped := &statusRecorder{ResponseWriter: w}
+
+			// Note: if the handler panics, RecoveryMiddleware (outermost)
+			// catches it and the log call below never executes. Panicked
+			// requests appear only in Recovery's error log, not here.
+			next.ServeHTTP(wrapped, r)
+
+			if r.URL.Path == "/health" {
+				return
+			}
+
+			status := wrapped.status
+			if status == 0 {
+				status = http.StatusOK
+			}
+
+			client := r.UserAgent()
+			if client == "" {
+				client = "unknown"
+			}
+
+			logger.Info("request",
+				"method", r.Method,
+				"path", r.URL.RequestURI(),
+				"status", status,
+				"duration", time.Since(start),
+				"client", client,
+			)
+		})
+	}
+}

--- a/serving-go/internal/api/middleware_test.go
+++ b/serving-go/internal/api/middleware_test.go
@@ -1,0 +1,469 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Compile-time guarantees that both wrappers expose the underlying
+// ResponseWriter via Unwrap. http.ResponseController and similar
+// helpers walk Unwrap chains; removing these would silently break
+// flushers, hijackers, etc.
+var _ interface{ Unwrap() http.ResponseWriter } = (*recoverWriter)(nil)
+var _ interface{ Unwrap() http.ResponseWriter } = (*statusRecorder)(nil)
+
+// capturingHandler is an slog.Handler that retains every record so
+// tests can assert on log fields. Logging is part of the JF-02
+// contract (panic-recovery log, /health skip, client="unknown" for
+// missing UA), so log assertions here are intentional, not
+// implementation-coupling.
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *capturingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func (h *capturingHandler) snapshot() []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]slog.Record, len(h.records))
+	copy(out, h.records)
+	return out
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func capturingLogger() (*slog.Logger, *capturingHandler) {
+	h := &capturingHandler{}
+	return slog.New(h), h
+}
+
+func attrValue(t *testing.T, r slog.Record, key string) (slog.Value, bool) {
+	t.Helper()
+	var found slog.Value
+	var ok bool
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			found = a.Value
+			ok = true
+			return false
+		}
+		return true
+	})
+	return found, ok
+}
+
+func requireAttr(t *testing.T, r slog.Record, key string) slog.Value {
+	t.Helper()
+	v, ok := attrValue(t, r, key)
+	if !ok {
+		t.Fatalf("log record %q missing attr %q", r.Message, key)
+	}
+	return v
+}
+
+// ---- Recovery middleware ---------------------------------------------------
+
+func TestRecoveryMiddleware_PanicReturns500(t *testing.T) {
+	logger, captured := capturingLogger()
+	panicHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("kaboom")
+	})
+	wrapped := RecoveryMiddleware(logger)(panicHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/explode", nil)
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+
+	body := w.Body.String()
+	var errResp ErrorResponse
+	if err := json.Unmarshal([]byte(body), &errResp); err != nil {
+		t.Fatalf("decode body: %v (body=%q)", err, body)
+	}
+	if errResp.Error != "internal server error" {
+		t.Errorf("error message = %q, want %q", errResp.Error, "internal server error")
+	}
+	if strings.Contains(body, "kaboom") {
+		t.Errorf("panic value leaked into response body: %q", body)
+	}
+
+	records := captured.snapshot()
+	if len(records) != 1 {
+		t.Fatalf("captured %d records, want 1", len(records))
+	}
+	rec := records[0]
+	if rec.Level != slog.LevelError {
+		t.Errorf("log level = %s, want ERROR", rec.Level)
+	}
+	if rec.Message != "panic recovered" {
+		t.Errorf("log message = %q, want %q", rec.Message, "panic recovered")
+	}
+	if v := requireAttr(t, rec, "method"); v.String() != http.MethodGet {
+		t.Errorf("method attr = %q, want %q", v.String(), http.MethodGet)
+	}
+	if v := requireAttr(t, rec, "path"); !strings.Contains(v.String(), "/explode") {
+		t.Errorf("path attr = %q, want to contain %q", v.String(), "/explode")
+	}
+	if v := requireAttr(t, rec, "stack"); v.String() == "" {
+		t.Error("stack attr is empty")
+	}
+	if _, ok := attrValue(t, rec, "error"); !ok {
+		t.Error("error attr missing from panic-recovered log")
+	}
+}
+
+func TestRecoveryMiddleware_NoPanicPassthrough(t *testing.T) {
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("ok"))
+	})
+	wrapped := RecoveryMiddleware(discardLogger())(okHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201", w.Code)
+	}
+	if w.Body.String() != "ok" {
+		t.Errorf("body = %q, want %q", w.Body.String(), "ok")
+	}
+}
+
+func TestRecoveryMiddleware_PanicAfterPartialWrite(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("partial body"))
+		panic("mid-write kaboom")
+	})
+	wrapped := RecoveryMiddleware(discardLogger())(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+
+	// Headers were already sent before the panic — recovery must not
+	// attempt a second WriteHeader and must not append the error JSON.
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (already sent before panic)", w.Code)
+	}
+	if got := w.Body.String(); got != "partial body" {
+		t.Errorf("body = %q, want exactly %q", got, "partial body")
+	}
+	if strings.Contains(w.Body.String(), "internal server error") {
+		t.Error("recovery wrote error JSON on top of an already-written response")
+	}
+}
+
+func TestRecoverWriter_WriteSetsWrittenFlag(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := &recoverWriter{ResponseWriter: rec}
+
+	if rw.written {
+		t.Fatal("written should be false before any write")
+	}
+	if _, err := rw.Write([]byte("x")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !rw.written {
+		t.Error("written should be true after Write")
+	}
+}
+
+func TestRecoverWriter_WriteHeaderSetsWrittenFlag(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := &recoverWriter{ResponseWriter: rec}
+
+	rw.WriteHeader(http.StatusTeapot)
+
+	if !rw.written {
+		t.Error("written should be true after WriteHeader")
+	}
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("underlying status = %d, want 418", rec.Code)
+	}
+}
+
+// ---- Status recorder -------------------------------------------------------
+
+func TestStatusRecorder_CapturesExplicitStatus(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sr := &statusRecorder{ResponseWriter: rec}
+
+	sr.WriteHeader(http.StatusNotFound)
+
+	if sr.status != http.StatusNotFound {
+		t.Errorf("recorder.status = %d, want 404", sr.status)
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("underlying status = %d, want 404", rec.Code)
+	}
+}
+
+func TestStatusRecorder_WriteWithoutHeaderDefaultsTo200(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sr := &statusRecorder{ResponseWriter: rec}
+
+	if _, err := sr.Write([]byte("hi")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if sr.status != http.StatusOK {
+		t.Errorf("recorder.status = %d, want 200 (defaulted on bare Write)", sr.status)
+	}
+}
+
+// ---- Logging middleware ----------------------------------------------------
+
+func TestLoggingMiddleware_LogsRequiredFields(t *testing.T) {
+	logger, captured := capturingLogger()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("created"))
+	})
+	wrapped := LoggingMiddleware(logger)(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/environmental?lat=52.5", nil)
+	req.Header.Set("User-Agent", "buttprint-api/0.1.0")
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201", w.Code)
+	}
+	if w.Body.String() != "created" {
+		t.Errorf("body = %q, want %q", w.Body.String(), "created")
+	}
+
+	records := captured.snapshot()
+	if len(records) != 1 {
+		t.Fatalf("captured %d log records, want 1", len(records))
+	}
+	rec := records[0]
+	if rec.Message != "request" {
+		t.Errorf("log message = %q, want %q", rec.Message, "request")
+	}
+	if rec.Level != slog.LevelInfo {
+		t.Errorf("log level = %s, want INFO", rec.Level)
+	}
+
+	checks := map[string]func(slog.Value) error{
+		"method":   stringEquals(http.MethodGet),
+		"path":     stringContains("/v1/environmental"),
+		"status":   int64Equals(int64(http.StatusCreated)),
+		"client":   stringEquals("buttprint-api/0.1.0"),
+		"duration": durationNonNegative(),
+	}
+	for key, check := range checks {
+		v, ok := attrValue(t, rec, key)
+		if !ok {
+			t.Errorf("log record missing attr %q", key)
+			continue
+		}
+		if err := check(v); err != nil {
+			t.Errorf("attr %q: %v", key, err)
+		}
+	}
+}
+
+func TestLoggingMiddleware_SkipsHealth(t *testing.T) {
+	logger, captured := capturingLogger()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	wrapped := LoggingMiddleware(logger)(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", w.Code)
+	}
+	if recs := captured.snapshot(); len(recs) != 0 {
+		t.Errorf("captured %d log records for /health, want 0", len(recs))
+	}
+}
+
+func TestLoggingMiddleware_StatusDefaultsTo200(t *testing.T) {
+	logger, captured := capturingLogger()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No WriteHeader — status should be inferred as 200.
+		w.Write([]byte("hi"))
+	})
+	wrapped := LoggingMiddleware(logger)(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+	wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+	records := captured.snapshot()
+	if len(records) != 1 {
+		t.Fatalf("captured %d records, want 1", len(records))
+	}
+	v := requireAttr(t, records[0], "status")
+	if v.Int64() != int64(http.StatusOK) {
+		t.Errorf("logged status = %d, want 200", v.Int64())
+	}
+}
+
+func TestLoggingMiddleware_MissingUserAgentLogsUnknown(t *testing.T) {
+	logger, captured := capturingLogger()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	wrapped := LoggingMiddleware(logger)(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/environmental", nil)
+	// Defensively clear the header in case future stdlib versions
+	// start populating it.
+	req.Header.Del("User-Agent")
+	wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+	records := captured.snapshot()
+	if len(records) != 1 {
+		t.Fatalf("captured %d records, want 1", len(records))
+	}
+	v := requireAttr(t, records[0], "client")
+	if v.String() != "unknown" {
+		t.Errorf("client = %q, want %q", v.String(), "unknown")
+	}
+}
+
+// ---- Composite stack -------------------------------------------------------
+
+func TestRecoveryAndLogging_StackSurvivesPanic(t *testing.T) {
+	logger, captured := capturingLogger()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /panic", func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	})
+	mux.HandleFunc("GET /ok", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	// Same wiring order as cmd/serving/main.go: recovery outermost.
+	var h http.Handler = mux
+	h = LoggingMiddleware(logger)(h)
+	h = RecoveryMiddleware(logger)(h)
+
+	// First request: panic. Stack must catch it.
+	{
+		req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("panic request status = %d, want 500", w.Code)
+		}
+		var errResp ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+			t.Fatalf("decode error response: %v (body=%q)", err, w.Body.String())
+		}
+		if errResp.Error != "internal server error" {
+			t.Errorf("error message = %q, want %q", errResp.Error, "internal server error")
+		}
+	}
+
+	// Second request: must still serve normally on the same chain.
+	{
+		req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("post-panic request status = %d, want 200", w.Code)
+		}
+		if w.Body.String() != "ok" {
+			t.Errorf("post-panic body = %q, want %q", w.Body.String(), "ok")
+		}
+	}
+
+	// Sanity-check that we observed both the panic-recovery log and a
+	// normal request log for the second call.
+	var sawPanicLog, sawRequestLog bool
+	for _, rec := range captured.snapshot() {
+		switch rec.Message {
+		case "panic recovered":
+			sawPanicLog = true
+		case "request":
+			if v, ok := attrValue(t, rec, "status"); ok && v.Int64() == int64(http.StatusOK) {
+				sawRequestLog = true
+			}
+		}
+	}
+	if !sawPanicLog {
+		t.Error("expected a 'panic recovered' log record")
+	}
+	if !sawRequestLog {
+		t.Error("expected a 'request' log record with status=200 for /ok")
+	}
+}
+
+// ---- attr-value helpers ----------------------------------------------------
+
+func stringEquals(want string) func(slog.Value) error {
+	return func(v slog.Value) error {
+		if v.String() != want {
+			return fmt.Errorf("got %q, want %q", v.String(), want)
+		}
+		return nil
+	}
+}
+
+func stringContains(sub string) func(slog.Value) error {
+	return func(v slog.Value) error {
+		if !strings.Contains(v.String(), sub) {
+			return fmt.Errorf("got %q, want to contain %q", v.String(), sub)
+		}
+		return nil
+	}
+}
+
+func int64Equals(want int64) func(slog.Value) error {
+	return func(v slog.Value) error {
+		if v.Int64() != want {
+			return fmt.Errorf("got %d, want %d", v.Int64(), want)
+		}
+		return nil
+	}
+}
+
+func durationNonNegative() func(slog.Value) error {
+	return func(v slog.Value) error {
+		if v.Kind() != slog.KindDuration {
+			return fmt.Errorf("kind = %s, want Duration", v.Kind())
+		}
+		if v.Duration() < 0 {
+			return fmt.Errorf("duration %s is negative", v.Duration())
+		}
+		return nil
+	}
+}

--- a/serving-go/internal/api/middleware_test.go
+++ b/serving-go/internal/api/middleware_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -48,10 +47,6 @@ func (h *capturingHandler) snapshot() []slog.Record {
 	out := make([]slog.Record, len(h.records))
 	copy(out, h.records)
 	return out
-}
-
-func discardLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 func capturingLogger() (*slog.Logger, *capturingHandler) {
@@ -142,7 +137,7 @@ func TestRecoveryMiddleware_NoPanicPassthrough(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte("ok"))
 	})
-	wrapped := RecoveryMiddleware(discardLogger())(okHandler)
+	wrapped := RecoveryMiddleware(slog.New(slog.DiscardHandler))(okHandler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -162,7 +157,7 @@ func TestRecoveryMiddleware_PanicAfterPartialWrite(t *testing.T) {
 		w.Write([]byte("partial body"))
 		panic("mid-write kaboom")
 	})
-	wrapped := RecoveryMiddleware(discardLogger())(handler)
+	wrapped := RecoveryMiddleware(slog.New(slog.DiscardHandler))(handler)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

- Adds `RecoveryMiddleware` and `LoggingMiddleware` to `serving-go`,
  wired as `Recovery(Logging(mux))` in `cmd/serving/main.go`.
- Splits the handler's coarse `ctx.Err()` check into separate
  `context.Canceled` (write nothing) and `context.DeadlineExceeded`
  (504) branches.
- Documents the 20s `WriteTimeout` / 18s inner-deadline relationship in
  `.claude/CLAUDE.md`.

## Behaviour

- **Recovery:** catches panics, logs `error` + `stack` + `method` +
  `path` via `slog.Error`, returns `{"error":"internal server error"}`
  with HTTP 500. Skips the error write if the panicking handler had
  already written response data.
- **Logging:** logs `method`, `path`, `status`, `duration`, `client`
  (from `User-Agent`; `"unknown"` if absent) at info level. `/health`
  is not logged. `status=0` is preserved in logs for requests that
  never wrote a body (client disconnects), so they stay
  distinguishable from real 200s.
- Both wrappers expose `Unwrap() http.ResponseWriter` so
  `http.ResponseController` can still reach `Flusher`/`Hijacker`.

## Test plan

- [x] `make test-short` passes
- [x] `go vet ./...` clean
