### PR TITLE
Bound CH nearest-neighbor query with spatial + temporal boxes (hotfix)

### DIFF
--- a/serving-go/internal/grid/finder.go
+++ b/serving-go/internal/grid/finder.go
@@ -13,6 +13,10 @@ import (
 	"github.com/kacper-wojtaszczyk/jackfruit/serving-go/internal/domain"
 )
 
+const boxTolerance = float32(0.5)
+
+const lookbackWindow = 24 * time.Hour
+
 type Finder struct {
 	conn driver.Conn
 }
@@ -37,15 +41,21 @@ func (c *Finder) GetSample(
         WHERE variable = @variable
           AND timestamp = (
             SELECT max(timestamp) FROM grid_data FINAL
-            WHERE variable = @variable AND timestamp <= @timestamp
+            WHERE variable = @variable
+              AND timestamp <= @timestamp
+              AND timestamp >= @tsFloor
           )
+          AND lat BETWEEN @lat - @tol AND @lat + @tol
+          AND lon BETWEEN @lon - @tol AND @lon + @tol
         ORDER BY (lat - @lat) * (lat - @lat) + (lon - @lon) * (lon - @lon)
         LIMIT 1
         `,
 		clickhouse.Named("variable", variable),
 		clickhouse.Named("timestamp", timestamp),
+		clickhouse.Named("tsFloor", timestamp.Add(-lookbackWindow)),
 		clickhouse.Named("lat", lat),
 		clickhouse.Named("lon", lon),
+		clickhouse.Named("tol", boxTolerance),
 	).Scan(&result.Value, &result.Unit, &result.Lat, &result.Lon, &result.CatalogID, &result.Timestamp)
 
 	if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
## What

Two `WHERE` constraints on the `/v1/environmental` ClickHouse nearest-neighbor query

1. **Spatial box** — `lat`/`lon BETWEEN @x ± @tol` (±0.5°).
2. **Temporal floor** — `timestamp >= request − 24h` on the latest-timestamp subquery.

No schema, API, or lineage changes. Two tunable constants (`boxTolerance`, `lookbackWindow`).

## Why

`/v1/environmental` was slow and timing out — two causes:

- **Constant cost:** no geometry filter meant a Euclidean-distance sort over the whole
  grid (~300K rows) per query. The box rides the `(variable, timestamp, lat, lon)` sort
  key, cutting the sort to a few dozen rows.
- **Growing cost (the "longer and longer"):** the `max(timestamp) … FINAL` subquery had
  no lower time bound, so the merge scanned all history for the variable. The 24h floor
  lets `PARTITION BY toYYYYMMDD(timestamp)` prune to **≤2 partitions**, keeping cost flat
  as data accumulates.

## Behavior changes (intentional)

- Requests far outside grid coverage now return `not-found` instead of a distant point.
- A data gap >24h around the requested time returns `not-found` rather than stale data
  (tunable via `lookbackWindow`).