### PR TITLE
INF-10: configurable serving-go Postgres sslmode [HOLD — merge at cutover]

### DIFF
--- a/serving-go/cmd/serving/main.go
+++ b/serving-go/cmd/serving/main.go
@@ -62,8 +62,8 @@ func newApp() (*app, error) {
 	chFinder := grid.NewFinder(chConn)
 
 	dsn := fmt.Sprintf(
-		"host=%s port=%s user=%s password=%s dbname=%s",
-		cfg.PostgresHost, cfg.PostgresPort, cfg.PostgresUser, cfg.PostgresPassword, cfg.PostgresDB,
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		cfg.PostgresHost, cfg.PostgresPort, cfg.PostgresUser, cfg.PostgresPassword, cfg.PostgresDB, cfg.PostgresSSLMode,
 	)
 	pgDB, err := sql.Open("postgres", dsn)
 	if err != nil {

--- a/serving-go/internal/config/config.go
+++ b/serving-go/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	PostgresUser       string
 	PostgresPassword   string
 	PostgresDB         string
+	PostgresSSLMode    string
 }
 
 func getEnv(key, fallback string) string {
@@ -40,5 +41,6 @@ func Load() *Config {
 		PostgresUser:       getEnv("POSTGRES_USER", "jackfruit"),
 		PostgresPassword:   getEnv("POSTGRES_PASSWORD", "jackfruit"),
 		PostgresDB:         getEnv("POSTGRES_DB", "jackfruit"),
+		PostgresSSLMode:    getEnv("POSTGRES_SSLMODE", "disable"), // in-cluster PG and local compose are both plaintext
 	}
 }

--- a/serving-go/internal/config/config_test.go
+++ b/serving-go/internal/config/config_test.go
@@ -1,0 +1,19 @@
+package config
+
+import "testing"
+
+func TestLoadPostgresSSLMode(t *testing.T) {
+	t.Run("defaults to disable", func(t *testing.T) {
+		t.Setenv("POSTGRES_SSLMODE", "")
+		if got := Load().PostgresSSLMode; got != "disable" {
+			t.Errorf("PostgresSSLMode = %q, want %q", got, "disable")
+		}
+	})
+
+	t.Run("honors override", func(t *testing.T) {
+		t.Setenv("POSTGRES_SSLMODE", "require")
+		if got := Load().PostgresSSLMode; got != "require" {
+			t.Errorf("PostgresSSLMode = %q, want %q", got, "require")
+		}
+	})
+}


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE until INF-10 cutover.** Pushing to `main` triggers `deploy.yml`, which rolls this image to prod. `sslmode=disable` must not run against the still-managed (TLS) Postgres, and the old `sslmode=require` image must not run against the no-TLS in-cluster Postgres. Kept as a **draft** on purpose — mark ready only during the cutover window, once the in-cluster PG + flipped secret are in place.

## What
Makes the Postgres `sslmode` configurable so serving-go can connect to the no-TLS in-cluster Postgres.

- `config.go` — new `PostgresSSLMode` field, env `POSTGRES_SSLMODE`, default `"disable"`.
- `main.go` — append `sslmode=%s` to the `lib/pq` DSN.
- `config_test.go` — asserts the `disable` default + env override.

## Why `disable`
`lib/pq` defaults to `sslmode=require` (unlike libpq's `prefer`), so today serving-go only connects because the managed instance offers TLS. The in-cluster pod serves plaintext, as does local `docker-compose`, so `disable` is correct for both. No manifest change needed; override via `POSTGRES_SSLMODE` if TLS is ever added.

## Verified locally
`gofmt -l` clean · `go vet` clean · `go build ./...` OK · `go test ./internal/config/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)