### PR TITLE
refactor: align float types for sample values

### DIFF
--- a/docs/ADR/004-per-source-lineage-shape.md
+++ b/docs/ADR/004-per-source-lineage-shape.md
@@ -1,0 +1,118 @@
+# ADR 004: Per-Source Lineage Shape
+
+## Status
+
+Proposed
+
+## Context
+
+The Jackfruit serving API returns environmental data for `(lat, lon, timestamp)` queries against gridded data in ClickHouse, enriched with lineage metadata from Postgres (`catalog.curated_data` joined to `catalog.raw_files`). The original lineage shape was a singleton `{source, dataset, raw_file_id}` per variable, on the assumption that each returned value corresponds to a single stored row identified by `catalog_id`.
+
+Two forcing functions break the singleton assumption:
+
+1. **Temporal interpolation (JF-06).** The redesigned spatiotemporal matching computes returned values as linear interpolations between two bracketing timestamps. Every non-exact-match response now has at least two raw rows contributing to its value. A singleton lineage cannot honestly describe this.
+
+2. **Licensing compliance.** Both CAMS (Copernicus License rev. 12) and ECMWF Open Data (CC BY 4.0 + ECMWF Terms) require source attribution at the user-facing distribution surface. The obligation is owed *per source*, not per cell. The pre-JF-06 response carried no attribution at all — a compliance gap that JF-06 also addresses.
+
+A third concern, surfaced during scoping but explicitly de-scoped from JF-06, is multi-source-per-variable (backlog item JF-F1 — DWD ICON-EU as a second source for `temperature`). The lineage shape chosen here must accommodate the multi-source case when it lands, without further contract change.
+
+### Options Considered
+
+**Option A: Singleton lineage (status quo)**
+
+Keep `{source, dataset, raw_file_id}` per variable. Pick one of the contributing rows as the "representative."
+
+- ✅ No contract change
+- ❌ Cannot honestly describe interpolated values; loses traceability to the second contributing row
+- ❌ Doesn't carry attribution metadata — compliance gap remains
+
+**Option B: Per-cell lineage with embedded attribution**
+
+The `lineage` field becomes a list of cell-level entries: `[{catalog_id, ref_timestamp, actual_lat, actual_lon, attribution_block}, ...]`.
+
+- ✅ Honest about interpolation
+- ✅ Carries attribution
+- ⚠️ Duplicates the full `AttributionBlock` for every entry — for 5 variables × 2 contributors sharing one source, the response carries 10 identical attribution blocks
+- ⚠️ FE rendering must dedup repeated attribution at display time
+- ⚠️ Per-cell granularity doesn't match the per-source granularity of the legal obligation
+
+**Option C: Per-source lineage with contributors**
+
+The `lineage` field is a list of per-source entries, each carrying one `AttributionBlock` and a list of contributors (the rows from that source).
+
+- ✅ Honest about interpolation — every contributing cell appears in `contributors`
+- ✅ Attribution at the granularity legally owed
+- ✅ No duplication when cells share a source
+- ✅ FE rendering: one attribution block per source per variable, no dedup logic
+- ✅ Multi-source-per-variable (JF-F1) is a natural fit — list grows from length-1 to length-N
+- ⚠️ Contract change requires lockstep updates in `buttprint-api` and `buttprint-fe`
+
+**Option D: Top-level deduped `attributions` block + per-cell lineage**
+
+A response-level `attributions: {source_key: AttributionBlock, ...}` block, separate from per-variable `lineage` arrays that reference sources by key.
+
+- ✅ Maximum wire-size compactness
+- ❌ Two structures to keep coherent — a stale key on a lineage entry would silently fail compliance
+- ❌ Less self-contained — consumers must cross-reference to render any single entry
+- ❌ Premature optimization at current response sizes (≤2 sources, ≤5 variables)
+
+## Decision
+
+Use **Option C: per-source lineage with contributors**.
+
+The Go domain types:
+
+```go
+type Lineage struct {
+    Source       string             // source key matching Postgres catalog.raw_files.source
+    Attribution  AttributionBlock   // one per source, with [YEAR] filled at response time
+    Contributors []ContributorRow   // the rows from this source that contributed
+}
+
+type ContributorRow struct {
+    CatalogID    uuid.UUID          // references catalog.curated_data.id
+    RefTimestamp time.Time          // the stored row's timestamp
+    ActualLat    float32
+    ActualLon    float32
+}
+```
+
+Per-variable response carries `lineage []Lineage` (always non-empty for successful responses). For today's single-source-per-variable reality, each list is length-1, and `Contributors` is length-1 (exact-match-on-latest case) or length-2 (interpolation pair).
+
+`AttributionBlock` carries `source`, `copyright` (with `[YEAR]` filled at response time using the *latest* contributor's `RefTimestamp.UTC().Year()` — keeps one `AttributionBlock` per source even when contributors span a year boundary), `license`, `license_url`, and `disclaimer` (where mandated).
+
+This shape applies to the new `/v1/environmental/point` endpoint introduced in JF-06. The old `/v1/environmental` retains its singleton-lineage contract until cutover, then is removed within the same milestone.
+
+## Consequences
+
+### Positive
+
+- **Honest about interpolation.** Every contributing cell is named in `Contributors`. Downstream consumers can compute the interpolation weight α from contributor timestamps and per-variable `applies_to_timestamp` without server-side metadata.
+- **Attribution at the granularity legally owed.** No wire-size duplication when cells share a source.
+- **Forward-compatible with multi-source-per-variable.** When JF-F1 lands, the lineage list grows from length-1 to length-N without further contract change.
+- **Simpler FE rendering.** No client-side dedup logic needed; the per-source shape already dedups at the variable level.
+- **Compliance gap closed.** Attribution is structurally mandatory rather than absent.
+
+### Negative
+
+- **Contract break, lockstep updates required.** `buttprint-api` (API-08) and `buttprint-fe` (FE-11) adopt the new shape in coordination with this change.
+- **Per-variable lineage is no longer an optional singleton.** Consumers cannot treat lineage as a flat optional field — the structure is mandatory and nested.
+- **Per-cell granularity available only via `Contributors`.** Consumers reasoning about which cell contributed at which timestamp must inspect the contributors list rather than reading flat `actual_lat`/`actual_lon` at the variable level.
+- **ADR 001 unchanged but narrower in role.** The Postgres join via `catalog_id` still materializes lineage; now each query may resolve multiple `catalog_id` values rather than one. No structural change to ADR 001.
+
+### Mitigations
+
+- **Lockstep updates planned.** API-08 and FE-11 land in the same milestone as JF-06; the URL split gives a clean cutover window rather than forcing a single atomic flip.
+- **Hardcoded Go source-spec map (not Postgres-backed yet).** The per-source `AttributionBlock` lives in `var sources = map[string]sourceSpec{...}` in Go code, not a `catalog.source` Postgres table. License strings change rarely; the migration is deferred until there are >5 sources or license strings begin changing.
+- **Lineage failures fail the request.** No fallback path emitting partial/static-attribution responses — the goal is contract honesty, not best-effort delivery.
+
+## References
+
+- JF-06 (rescoped): spatiotemporal matching + lineage/compliance redesign.
+- API-08: `buttprint-api` adoption of the new lineage shape.
+- FE-11: `buttprint-fe` adoption of the new lineage shape.
+- JF-F1 (backlog): multi-source-per-variable disambiguation — accommodated by this shape without further contract change.
+- [ADR 001](001-grid-data-storage.md) — Grid data storage abstraction. Unchanged; `catalog_id` join still materializes lineage.
+- Domain types (post-JF-06): `serving-go/internal/domain/lineage.go` (`Lineage`, `ContributorRow`).
+- Source spec (new package, post-JF-06): `serving-go/internal/source/spec.go` (`AttributionBlock`, `sourceSpec`).
+- JSON wire shape (post-JF-06): `serving-go/internal/api/response.go`.

--- a/docs/layer-2-transformation.md
+++ b/docs/layer-2-transformation.md
@@ -129,12 +129,14 @@ client.insert(
         np.full(grid.row_count, grid.timestamp, dtype=object),
         grid.lats.ravel().astype(np.float32),
         grid.lons.ravel().astype(np.float32),
-        grid.values.ravel().astype(np.float32),
+        grid.values.ravel().astype(np.float64),
         np.full(grid.row_count, grid.unit, dtype=object),
         np.full(grid.row_count, grid.catalog_id, dtype=object),
     ],
 )
 ```
+
+**Note:** `value` is `Float64` in ClickHouse and the pipeline writes `float64`. If your local docker-compose ClickHouse volume predates this change, re-create it (or run `ALTER TABLE grid_data MODIFY COLUMN value Float64`) — the serving-go driver refuses to scan across float widths, so a stale `Float32` column breaks integration tests.
 
 **Schema:** `inserted_at` is auto-filled by `DEFAULT now64(3)`.
 

--- a/pipeline-python/migrations/clickhouse/init.sql
+++ b/pipeline-python/migrations/clickhouse/init.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS jackfruit.grid_data (
     timestamp    DateTime,
     lat          Float32,
     lon          Float32,
-    value        Float32,
+    value        Float64,
     unit         LowCardinality(String),
     catalog_id   UUID,
     inserted_at  DateTime64(3) DEFAULT now64(3)

--- a/pipeline-python/src/pipeline_python/storage/clickhouse_grid_store.py
+++ b/pipeline-python/src/pipeline_python/storage/clickhouse_grid_store.py
@@ -61,7 +61,7 @@ class ClickHouseGridStore(GridStore):
                 np.full(grid.row_count, grid.timestamp, dtype=object),
                 grid.lats.ravel().astype(np.float32),
                 grid.lons.ravel().astype(np.float32),
-                grid.values.ravel().astype(np.float32),
+                grid.values.ravel().astype(np.float64),
                 np.full(grid.row_count, grid.unit, dtype=object),
                 np.full(grid.row_count, grid.catalog_id, dtype=object),
             ],

--- a/serving-go/internal/api/handler.go
+++ b/serving-go/internal/api/handler.go
@@ -73,7 +73,7 @@ func (h *Handler) handleEnvironmental(w http.ResponseWriter, r *http.Request) {
 	for i, varResult := range varResults {
 		response.Variables[i] = VariableResponse{
 			Name:         varResult.Name,
-			Value:        float64(varResult.Value),
+			Value:        varResult.Value,
 			Unit:         varResult.Unit,
 			RefTimestamp: varResult.RefTimestamp,
 			ActualLat:    varResult.ActualLat,

--- a/serving-go/internal/api/handler_integration_test.go
+++ b/serving-go/internal/api/handler_integration_test.go
@@ -62,7 +62,7 @@ func TestEnvironmentalHandler(t *testing.T) {
 		lat := float32(52.5)
 		lon := float32(13.4)
 
-		catalogID := testutil.InsertGridRow(t, rawConn, "pm2p5", float32(12.5), "µg/m³", ts, lat, lon)
+		catalogID := testutil.InsertGridRow(t, rawConn, "pm2p5", 12.5, "µg/m³", ts, lat, lon)
 		rawFileID := testutil.SeedLineage(t, pgDB, catalogID, "ads", "cams-europe-air-quality-forecast", "pm2p5", "µg/m³")
 
 		url := fmt.Sprintf("/v1/environmental?lat=%v&lon=%v&timestamp=%s&variables=pm2p5",
@@ -87,7 +87,7 @@ func TestEnvironmentalHandler(t *testing.T) {
 		if v.Name != "pm2p5" {
 			t.Errorf("expected name pm2p5, got %q", v.Name)
 		}
-		if float32(v.Value) != float32(12.5) {
+		if v.Value != 12.5 {
 			t.Errorf("expected value 12.5, got %v", v.Value)
 		}
 		if v.Unit != "µg/m³" {
@@ -110,8 +110,8 @@ func TestEnvironmentalHandler(t *testing.T) {
 		lat := float32(48.1)
 		lon := float32(11.6)
 
-		catID1 := testutil.InsertGridRow(t, rawConn, "pm2p5_multi", float32(8.1), "µg/m³", ts, lat, lon)
-		catID2 := testutil.InsertGridRow(t, rawConn, "no2_multi", float32(20.3), "µg/m³", ts, lat, lon)
+		catID1 := testutil.InsertGridRow(t, rawConn, "pm2p5_multi", 8.1, "µg/m³", ts, lat, lon)
+		catID2 := testutil.InsertGridRow(t, rawConn, "no2_multi", 20.3, "µg/m³", ts, lat, lon)
 		rawFileID1 := testutil.SeedLineage(t, pgDB, catID1, "ads", "cams-europe-air-quality-forecast", "pm2p5_multi", "µg/m³")
 		rawFileID2 := testutil.SeedLineage(t, pgDB, catID2, "ads", "cams-europe-air-quality-forecast", "no2_multi", "µg/m³")
 
@@ -142,7 +142,7 @@ func TestEnvironmentalHandler(t *testing.T) {
 		if v, ok := byName["pm2p5_multi"]; !ok {
 			t.Error("expected pm2p5_multi in response")
 		} else {
-			if float32(v.Value) != float32(8.1) {
+			if v.Value != 8.1 {
 				t.Errorf("expected pm2p5_multi value 8.1, got %v", v.Value)
 			}
 			assertLineage(t, v.Lineage, "ads", "cams-europe-air-quality-forecast", rawFileID1)
@@ -151,7 +151,7 @@ func TestEnvironmentalHandler(t *testing.T) {
 		if v, ok := byName["no2_multi"]; !ok {
 			t.Error("expected no2_multi in response")
 		} else {
-			if float32(v.Value) != float32(20.3) {
+			if v.Value != 20.3 {
 				t.Errorf("expected no2_multi value 20.3, got %v", v.Value)
 			}
 			assertLineage(t, v.Lineage, "ads", "cams-europe-air-quality-forecast", rawFileID2)
@@ -184,7 +184,7 @@ func TestEnvironmentalHandler(t *testing.T) {
 		gridLat := float32(52.5)
 		gridLon := float32(13.4)
 
-		catalogID := testutil.InsertGridRow(t, rawConn, "pm2p5_nn", float32(9.9), "µg/m³", ts, gridLat, gridLon)
+		catalogID := testutil.InsertGridRow(t, rawConn, "pm2p5_nn", 9.9, "µg/m³", ts, gridLat, gridLon)
 		rawFileID := testutil.SeedLineage(t, pgDB, catalogID, "ads", "cams-europe-air-quality-forecast", "pm2p5_nn", "µg/m³")
 
 		// Request at slightly different coords — should snap to the nearest grid point.

--- a/serving-go/internal/domain/environmental.go
+++ b/serving-go/internal/domain/environmental.go
@@ -20,7 +20,7 @@ func (e *ErrVariableNotFound) Error() string {
 
 type VariableResult struct {
 	Name         string
-	Value        float32
+	Value        float64
 	Unit         string
 	RefTimestamp time.Time
 	ActualLat    float32

--- a/serving-go/internal/domain/environmental_test.go
+++ b/serving-go/internal/domain/environmental_test.go
@@ -47,7 +47,7 @@ func (m *mockLineageRetriever) GetLineage(ctx context.Context, catalogID uuid.UU
 
 func TestService_GetVariables(t *testing.T) {
 	variableNames := [2]string{"pm2p5", "pm10"}
-	values := [2]float32{1.0, 0.001}
+	values := [2]float64{1.0, 0.001}
 	units := [2]string{"µg/m³", "ng/m³"}
 	lats := [2]float32{75.05, 75.1}
 	lons := [2]float32{106.25, 106.2}

--- a/serving-go/internal/domain/grid.go
+++ b/serving-go/internal/domain/grid.go
@@ -11,7 +11,7 @@ import (
 var ErrGridSampleNotFound = errors.New("grid sample not found")
 
 type GridSample struct {
-	Value     float32
+	Value     float64
 	Unit      string
 	Lat       float32
 	Lon       float32

--- a/serving-go/internal/grid/finder_integration_test.go
+++ b/serving-go/internal/grid/finder_integration_test.go
@@ -19,7 +19,7 @@ func TestGetSample(t *testing.T) {
 	rawConn := testutil.NewRawConn(t)
 
 	variable := "pm2p5"
-	value := float32(3.05)
+	value := float64(3.05)
 	unit := "µg/m³"
 	// Truncate to seconds: ClickHouse DateTime has second precision.
 	timestamp := time.Now().UTC().Truncate(time.Second)

--- a/serving-go/internal/testutil/clickhouse.go
+++ b/serving-go/internal/testutil/clickhouse.go
@@ -36,7 +36,7 @@ func NewRawConn(t *testing.T) chdriver.Conn {
 
 // InsertGridRow inserts a single row into grid_data and registers cleanup.
 // It generates and returns the catalog_id so callers can assert on it.
-func InsertGridRow(t *testing.T, conn chdriver.Conn, variable string, value float32, unit string,
+func InsertGridRow(t *testing.T, conn chdriver.Conn, variable string, value float64, unit string,
 	timestamp time.Time, lat, lon float32) uuid.UUID {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Widen the `value` column of ClickHouse `grid_data` — and the Go/Python types that read and write it — from 32-bit to 64-bit float, end to end.

**What this buys:** not precision (`float32` already over-resolves environmental values by orders of magnitude), but **type consistency**. The JSON wire is already `float64`, and this removes the last `float32` narrowing round-trip at the storage boundary and in the serving domain types. This is a consistency change, not an optimization.

## Changes

**Pipeline (order-tolerant):**
- `pipeline-python/migrations/clickhouse/init.sql` — canonical local DDL now creates `value Float64`
- `clickhouse_grid_store.py` — stop truncating at insert: `values.astype(np.float32)` → `np.float64`. The transforms (K→°C, Magnus RH) already compute in float64; this line was discarding that at the boundary
- `docs/layer-2-transformation.md` — snippet updated + note on migrating stale local ClickHouse volumes

**Serving-go (strict-scan coupled):**
- `GridSample.Value` / `VariableResult.Value`: `float32` → `float64`. `lat`/`lon`/`actual_*` deliberately stay `float32` (grid coords are exact at 0.1°/0.25°)
- Redundant `float64(...)` cast removed from the response build in `handler.go`; wire format unchanged
- Test helpers and assertions updated accordingly

## ⚠️ Deployment constraint — do not ship standalone

`clickhouse-go/v2` refuses to scan across float widths:

- New serving-go against a still-`Float32` live column → **scan error**
- Old serving-go against an already-`Float64` live column → **scan error**

There is no independent deploy order. The live-cluster `ALTER TABLE grid_data MODIFY COLUMN value Float64` and the new serving-go image must roll as a **coordinated cutover**, driven by the infra companion runbook (`JF-07-value-float64-infra.md`). Land/build this first so images exist; merge is **not** deployment.

The pipeline side is order-tolerant (a float32 write widens into a `Float64` column fine); only the serving read is strict.